### PR TITLE
Add terminating/init proposal

### DIFF
--- a/keps/core/0003-workspace-lifecycle-rbac.md
+++ b/keps/core/0003-workspace-lifecycle-rbac.md
@@ -1,0 +1,445 @@
+# Workspace Lifecycle Content Access Enhancement Proposal
+
+## Summary
+
+Replace the annotation-based workspace owner identity with a structured API field on
+`LogicalCluster`, and introduce RBAC-gated impersonation for initializing and terminating
+virtual workspace content proxies. Additionally, add workspace content access to the
+terminating virtual workspace, which currently lacks it entirely.
+
+## Motivation
+
+The current workspace lifecycle has several gaps (see also
+[kcp-dev/kcp#3647](https://github.com/kcp-dev/kcp/issues/3647)):
+
+1. **Owner identity stored as annotation.** The workspace owner is serialized as JSON in the
+   `experimental.tenancy.kcp.io/owner` annotation on the Workspace object
+   (`staging/src/github.com/kcp-dev/sdk/apis/tenancy/v1alpha1/types_workspace.go:58-59`).
+   The initializing virtual workspace content proxy reads this annotation from the LogicalCluster
+   to impersonate the owner when forwarding requests
+   (`pkg/virtual/initializingworkspaces/builder/build.go:241-254`). Annotations are untyped,
+   unvalidated, and can be mutated by anyone with update access — making them unsuitable for
+   security-critical identity data.
+
+2. **Owner group information is wiped on Ready phase.** When a LogicalCluster transitions to
+   `Ready`, the metadata reconciler
+   (`pkg/reconciler/core/logicalcluster/logicalcluster_reconcile_metadata.go:99-117`) strips
+   all fields except `Username` from the owner annotation. This means by the time a workspace
+   reaches termination, the owner's groups, UID, and extra info are already lost. Even if the
+   terminating virtual workspace attempted the same impersonation mechanism as the initializing
+   VW, it would impersonate the owner without their groups — potentially breaking group-based
+   RBAC evaluation. This is also not backwards compatible: workspaces created before any fix
+   would already have lost the group data.
+
+3. **Terminating workspaces have no content access.** The terminating virtual workspace
+   (`pkg/virtual/terminatingworkspaces/builder/build.go`) only exposes LogicalCluster
+   list/watch and status updates. Terminator controllers cannot access actual workspace
+   content to clean up resources. The workspace content authorizer
+   (`pkg/authorization/workspace_content_authorizer.go:112-114`) blocks all access for
+   workspaces not in `Initializing` or `Ready` phase.
+
+4. **No separate RBAC gate for workspace content access.** Currently, having the `initialize`
+   verb on a workspacetype implicitly grants access to the workspace content proxy (for the
+   initializing VW). There is no separate authorization step that distinguishes "can access
+   LogicalCluster VW endpoints" from "can access workspace content." The content proxy
+   impersonates the workspace owner — who has `cluster-admin` inside the workspace via the
+   `workspace-admin` ClusterRoleBinding
+   (`pkg/reconciler/tenancy/logicalcluster/logicalcluster_controller.go:236-250`) — but the
+   controller itself may be a service account with limited permissions. Not every controller
+   with VW access should automatically get this elevated content access.
+
+### Goals
+
+1. Move workspace owner identity from annotation to a structured, immutable field on
+   `LogicalCluster`.
+2. Introduce RBAC-gated impersonation on `WorkspaceType` so that controllers can be
+   explicitly authorized to access workspace content with elevated privileges during
+   initialization and termination. So not everybody with VW access automatically gets elevated access.
+3. Add a workspace content proxy to the terminating virtual workspace, matching the
+   capability that already exists for the initializing virtual workspace.
+
+### Non-Goals
+
+- General-purpose workspace content access outside of init/term phases. The `impersonate`
+  verb on `workspacetypes` only applies to the virtual workspace content proxies, not to
+  direct workspace access.
+- Changing the workspace content authorizer phase gate. The authorizer continues to block
+  direct access to non-`Initializing`/non-`Ready` workspaces. The virtual workspace proxies
+  bypass this by hitting the shard directly with impersonation.
+- Per-initializer or per-terminator impersonation identity selection. All controllers with
+  the `impersonate` verb on a given WorkspaceType get the same elevated identity.
+
+## Proposal
+
+### Part 1: Structured Owner Identity on LogicalCluster
+
+#### API Changes
+
+Add a new type and field to `LogicalClusterSpec`
+(`staging/src/github.com/kcp-dev/sdk/apis/core/v1alpha1/logicalcluster_types.go`):
+
+```go
+type LogicalClusterSpec struct {
+    // ...existing fields (DirectlyDeletable, Owner, Initializers, Terminators)...
+
+    // ownerUser is the identity of the user who created this workspace.
+    // Set by the system at workspace creation time. Immutable after creation.
+    // Used by virtual workspace content proxies to determine the default
+    // impersonation identity during initialization and termination.
+    //
+    // +optional
+    OwnerUser *LogicalClusterOwnerUser `json:"ownerUser,omitempty"`
+}
+
+// LogicalClusterOwnerUser holds the identity of the workspace creator.
+type LogicalClusterOwnerUser struct {
+    // username is the username of the user who created the workspace.
+    //
+    // +required
+    // +kubebuilder:validation:Required
+    // +kubebuilder:validation:MinLength=1
+    Username string `json:"username"`
+
+    // uid is the UID of the user.
+    //
+    // +optional
+    UID string `json:"uid,omitempty"`
+
+    // groups are the groups the user belongs to.
+    //
+    // +optional
+    Groups []string `json:"groups,omitempty"`
+
+    // extra contains additional user information.
+    //
+    // +optional
+    Extra map[string]ExtraValue `json:"extra,omitempty"`
+}
+
+// ExtraValue masks the value so protobuf can generate.
+type ExtraValue []string
+```
+
+#### Controller and Admission Changes
+
+| Component | File | Change |
+|---|---|---|
+| Workspace admission | `pkg/admission/workspace/admission.go:95-108` | On workspace creation, set `ownerUser` on the Workspace (to be propagated to LogicalCluster) in addition to the existing annotation |
+| LogicalCluster admission | `pkg/admission/logicalcluster/admission.go` | Validate that `spec.ownerUser` is immutable after creation |
+| LogicalCluster controller | `pkg/reconciler/tenancy/logicalcluster/logicalcluster_controller.go:236-250` | Read owner from `spec.ownerUser` instead of annotation when creating `workspace-admin` CRB |
+| Initializing VW content proxy | `pkg/virtual/initializingworkspaces/builder/build.go:241-254` | Read from `spec.ownerUser` instead of annotation; fall back to annotation for migration |
+
+#### Migration
+
+During transition, the content proxy reads `spec.ownerUser` first, falling back to the
+`experimental.tenancy.kcp.io/owner` annotation. The annotation is deprecated and will be
+removed in a future release.
+
+### Part 2: RBAC-Gated Impersonation via WorkspaceType
+
+#### Problem
+
+An initializer or terminator controller is typically a service account with narrow permissions:
+it can list/watch LogicalClusters via the virtual workspace and update their status. Currently,
+having the `initialize` or `terminate` verb on a workspacetype grants access to the VW's
+LogicalCluster endpoints, but also — implicitly and unconditionally — grants access to the
+workspace content proxy (for initializing VW). There is no separate RBAC gate that controls
+whether a controller is authorized to access workspace content.
+
+Not every controller with VW access should automatically get workspace content access. The
+`impersonate` verb provides an explicit, separate authorization gate for content access.
+
+#### New RBAC Verb: `impersonate`
+
+Introduce a new verb `impersonate` on the `workspacetypes` resource in the `tenancy.kcp.io`
+API group. This verb controls whether a controller is allowed to access workspace content
+through the virtual workspace content proxy. When granted, the proxy impersonates the workspace
+owner (who has `cluster-admin` inside the workspace via the `workspace-admin` ClusterRoleBinding
+created at `pkg/reconciler/tenancy/logicalcluster/logicalcluster_controller.go:236-250`).
+
+The controller itself may be a service account with limited permissions. The `impersonate` verb
+is what explicitly authorizes it to operate as the owner — and therefore as `cluster-admin` —
+inside the workspace content.
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: universal-initializer
+rules:
+  # Gate 1: Can access the initializing virtual workspace (LogicalCluster list/watch/status)
+  - verbs: ["initialize"]
+    resources: ["workspacetypes"]
+    resourceNames: ["universal"]
+    apiGroups: ["tenancy.kcp.io"]
+  # Gate 2: Can access workspace content via proxy (impersonating the owner)
+  - verbs: ["impersonate"]
+    resources: ["workspacetypes"]
+    resourceNames: ["universal"]
+    apiGroups: ["tenancy.kcp.io"]
+```
+
+Similarly for terminators:
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: universal-terminator
+rules:
+  - verbs: ["terminate"]
+    resources: ["workspacetypes"]
+    resourceNames: ["universal"]
+    apiGroups: ["tenancy.kcp.io"]
+  - verbs: ["impersonate"]
+    resources: ["workspacetypes"]
+    resourceNames: ["universal"]
+    apiGroups: ["tenancy.kcp.io"]
+```
+
+A controller with only `initialize`/`terminate` (without `impersonate`) can list/watch
+LogicalClusters and update their status, but **cannot** access workspace content.
+
+#### Content Proxy Authorization Flow
+
+When a controller accesses workspace content through the virtual workspace proxy:
+
+```
+1. Controller sends request to VW content endpoint
+   /services/initializingworkspaces/<initializer>/clusters/<cluster>/<resource-path>
+
+2. VW checks "initialize" verb on workspacetypes (existing)
+   → Deny: 403 Forbidden
+   → Allow: proceed
+
+3. VW checks workspace phase and initializer presence (existing)
+   → Phase != Initializing or initializer not in status.initializers: 403 Forbidden
+   → OK: proceed
+
+4. VW checks "impersonate" verb on workspacetypes (NEW)
+   → Allow: proxy impersonates workspace owner from spec.ownerUser
+   → Deny/NoOpinion: 403 Forbidden — content access not authorized
+```
+
+The same flow applies to the terminating virtual workspace, substituting `terminate` for
+`initialize` and checking `deletionTimestamp` + `status.terminators`.
+
+#### Impersonation Target
+
+The proxy always impersonates the **workspace owner** from `spec.ownerUser` on the
+LogicalCluster. The owner is bound to `cluster-admin` inside the workspace via the
+`workspace-admin` ClusterRoleBinding
+(`pkg/reconciler/tenancy/logicalcluster/logicalcluster_controller.go:236-250`), giving the
+proxied request full access to workspace content.
+
+The `impersonate` verb does not change who is impersonated — it gates whether the controller
+is allowed to access content at all. This provides a clear separation:
+
+- `initialize`/`terminate` → access to LogicalCluster VW endpoints
+- `impersonate` → access to workspace content (as the owner)
+
+#### Implementation Changes
+
+| Component | File | Change |
+|---|---|---|
+| Initializing VW content proxy | `pkg/virtual/initializingworkspaces/builder/build.go:223-288` | Add delegated SAR check for `impersonate` verb before proxying; deny if not authorized |
+| Terminating VW content proxy | New code (see Part 3) | Same `impersonate` check before proxying |
+| ClusterRole replication | `pkg/reconciler/tenancy/replicateclusterrole/replicateclusterrole_controller.go:60` | Add `impersonate` to the set of verbs that trigger replication |
+
+### Part 3: Terminating Virtual Workspace Content Proxy
+
+#### Current State
+
+The terminating virtual workspace (`pkg/virtual/terminatingworkspaces/builder/build.go:56-159`)
+exposes two sub-workspaces:
+
+| Name | Purpose |
+|---|---|
+| `wildcardLogicalClusters` | List/watch LogicalClusters with deletionTimestamp, filtered by terminator label |
+| `logicalClusters` | Get/update individual LogicalCluster status (remove own terminator only) |
+
+There is no `workspaceContent` sub-workspace. Terminators cannot access resources inside the
+workspace to clean up before deletion.
+
+#### Proposed Addition
+
+Add a third sub-workspace `workspaceContent` to the terminating virtual workspace, mirroring
+the pattern in the initializing virtual workspace
+(`pkg/virtual/initializingworkspaces/builder/build.go:165-291`).
+
+URL pattern:
+```
+/services/terminatingworkspaces/<terminator>/clusters/<cluster>/<resource-path>
+```
+
+#### Handler Logic
+
+```
+1. Parse terminator name from URL path (existing digestUrl function)
+
+2. Reject if cluster is wildcard (content access requires specific cluster)
+
+3. Reject if path is a logicalclusters.core.kcp.io request
+   (handled by the existing logicalClusters sub-workspace)
+
+4. Look up LogicalCluster from informer cache
+
+5. Validate:
+   - LogicalCluster has deletionTimestamp set
+   - Terminator is present in status.terminators
+   → Reject with 403 if either check fails
+
+6. Check "impersonate" verb on workspacetypes for this terminator (Part 2)
+   → Deny/NoOpinion: 403 Forbidden — content access not authorized
+   → Allow: proceed
+
+7. Read owner identity from spec.ownerUser on LogicalCluster
+
+8. Reverse-proxy request to the workspace shard, impersonating the owner
+```
+
+#### Implementation Changes
+
+| Component | File | Change |
+|---|---|---|
+| Terminating VW builder | `pkg/virtual/terminatingworkspaces/builder/build.go` | Add `workspaceContent` handler as third named VW; accept `wildcardKcpInformers` parameter |
+| Terminating VW builder | `pkg/virtual/terminatingworkspaces/builder/build.go:61-66` | Add `workspaceContentName` constant |
+| Terminating VW registration | Where `BuildVirtualWorkspace` is called | Pass `wildcardKcpInformers` (same as initializing VW does) |
+
+The `workspaceContent` handler for the terminating VW is structurally identical to
+`pkg/virtual/initializingworkspaces/builder/build.go:165-291`, with these differences:
+
+- Checks `status.terminators` instead of `status.initializers`
+- Checks `deletionTimestamp` is set instead of `phase == Initializing`
+- Uses the `termination.TypeFrom` function instead of `initialization.TypeFrom`
+- Requires `impersonate` verb to access content (same as initializing VW after this proposal)
+
+## RBAC Summary
+
+The following table summarizes the verbs on `workspacetypes` and what they gate:
+
+| Verb | Resource | Purpose | Where Checked |
+|---|---|---|---|
+| `use` | `workspacetypes` | Can create workspaces of this type | Workspace admission |
+| `initialize` | `workspacetypes` | Can access the initializing virtual workspace | Initializing VW authorizer |
+| `terminate` | `workspacetypes` | Can access the terminating virtual workspace | Terminating VW authorizer |
+| `impersonate` | `workspacetypes` | Can access workspace content via proxy (impersonating the owner) during init/term | VW content proxy (NEW) |
+
+Example: a controller that initializes workspaces of type `tenant` and needs content access:
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: tenant-initializer
+rules:
+  - verbs: ["initialize", "impersonate"]
+    resources: ["workspacetypes"]
+    resourceNames: ["tenant"]
+    apiGroups: ["tenancy.kcp.io"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: tenant-initializer
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: tenant-initializer
+subjects:
+  - kind: ServiceAccount
+    name: tenant-initializer-controller
+    namespace: default
+```
+
+This ClusterRole and ClusterRoleBinding must exist in the workspace where the `tenant`
+WorkspaceType is defined. The `replicateclusterrole` controller
+(`pkg/reconciler/tenancy/replicateclusterrole/replicateclusterrole_controller.go:60`)
+ensures ClusterRoles with `use`, `initialize`, `terminate`, or `impersonate` verbs on
+`workspacetypes` are replicated across the hierarchy.
+
+## Implementation Phases
+
+```
+Phase 1: Owner Identity (Part 1)
+  - Add LogicalClusterOwnerUser type and ownerUser field to LogicalClusterSpec
+  - Update workspace admission to populate ownerUser
+  - Update logicalcluster admission to enforce immutability
+  - Update logicalcluster controller to read ownerUser for workspace-admin CRB
+  - Update initializing VW content proxy to read from spec.ownerUser
+  - Deprecate experimental.tenancy.kcp.io/owner annotation
+
+Phase 2: Impersonation RBAC (Part 2)
+  - Add "impersonate" verb check to initializing VW authorizer and content proxy
+  - Add "impersonate" to replicateclusterrole verb set
+  - Add e2e tests for impersonation gating
+
+Phase 3: Terminating VW Content Access (Part 3)
+  - Add workspaceContent handler to terminating VW
+  - Wire informers into terminating VW builder
+  - Integrate impersonation RBAC from Phase 2
+  - Add e2e tests for terminator content access
+```
+
+## Relationship to Existing Issues
+
+This proposal addresses [kcp-dev/kcp#3647](https://github.com/kcp-dev/kcp/issues/3647)
+("Allow accessing workspace content through terminating virtualworkspace").
+
+That issue identified two core problems:
+1. The owner annotation's group info is wiped when a workspace reaches Ready
+   (`logicalcluster_reconcile_metadata.go:99-117`), making owner impersonation impossible
+   for terminators.
+2. The terminating VW has no content proxy at all.
+
+The issue discussion considered several approaches:
+- **Not wiping group data**: Would fix the immediate problem but is not backwards compatible
+  for existing workspaces, and still couples content access to the owner identity.
+- **Dynamically creating RBAC**: For controllers with `terminate`/`initialize` verbs, create
+  ephemeral ClusterRoleBindings granting workspace content access. This adds complexity around
+  lifecycle management of those RBAC objects.
+- **God-like permissions for the VW**: Giving the terminating VW system-level access. Too
+  broad and insecure.
+
+This proposal takes a different approach: structured owner identity (solving the data-loss
+problem) combined with RBAC-gated impersonation (decoupling content access from the owner
+entirely). The `impersonate` verb on workspacetypes provides explicit, auditable authorization
+for elevated access without ephemeral RBAC objects or annotation hacks.
+
+### Backwards Compatibility
+
+For workspaces created before this enhancement:
+- **Owner identity**: The `spec.ownerUser` field will not be set. The content proxy falls back
+  to the annotation. If the annotation has already been stripped to username-only (workspace
+  reached Ready), the owner can still be impersonated by username — the `workspace-admin`
+  ClusterRoleBinding (`pkg/reconciler/tenancy/logicalcluster/logicalcluster_controller.go:236-250`)
+  binds by username, not by group, so `cluster-admin` access still works.
+- **Impersonate verb**: Controllers with the `impersonate` verb bypass the owner identity
+  entirely, using the `kcp-admin` system identity. This works regardless of whether
+  `spec.ownerUser` or the annotation exists.
+- **Group-wiping removal**: As part of Phase 1, the group-wiping logic in
+  `logicalcluster_reconcile_metadata.go:99-117` should be removed. With owner identity moving
+  to an immutable spec field, there is no longer a reason to strip data from the annotation.
+
+## Open Questions
+
+1. **Should `impersonate` without `initialize`/`terminate` be meaningful?**
+   Currently, `impersonate` only applies to controllers that already have VW access via
+   `initialize` or `terminate`. The content proxy requires both: VW access (`initialize`/
+   `terminate`) AND content access (`impersonate`). Should `impersonate` alone ever grant
+   anything?
+
+2. **Annotation removal timeline.**
+   How long should the `experimental.tenancy.kcp.io/owner` annotation be supported as a
+   fallback before removal?
+
+3. **Should the group-wiping logic be removed entirely or made conditional?**
+   The current code strips group/UID/extra from the owner annotation on Ready. With
+   `spec.ownerUser` as the source of truth, the annotation becomes redundant. Should
+   we stop wiping immediately, or keep the behavior until the annotation is fully deprecated?
+
+4. **Should the existing initializing VW content proxy require `impersonate`?**
+   Today, any controller with the `initialize` verb can access workspace content implicitly.
+   Adding the `impersonate` requirement is a breaking change for existing initializer
+   controllers. Should this be enforced immediately or introduced with a deprecation period
+   where the old behavior (implicit content access with `initialize` only) is preserved?

--- a/keps/core/0003-workspace-lifecycle-rbac.md
+++ b/keps/core/0003-workspace-lifecycle-rbac.md
@@ -36,23 +36,32 @@ The current workspace lifecycle has several gaps (see also
 5. **Misleading audit logs.** The content proxy impersonates the workspace owner identity.
    Audit logs cannot distinguish whether a request came from the actual owner or a controller
    impersonating them. With multiple initializers/terminators, controllers are
-   indistinguishable from each other and from the owner.
+   indistinguishable from each other and from the owner. Clear attribution is a first-class
+   goal of this proposal.
 
 6. **No `Terminating` phase.** Workspaces that are being terminated show as `Ready` in
    `kubectl get workspaces`. There is no way to tell which workspaces are stuck in termination
    without inspecting deletion timestamps and terminator lists.
+
+All initializing/terminating VW requests continue to be routed through the FrontProxy (not
+directly to shards), as today. This is unchanged by this proposal — the VW machinery is a
+replicated, front-proxy-served concern by design.
 
 ### Goals
 
 1. Move workspace owner identity from annotation to a structured, immutable field on
    `LogicalCluster`.
 2. Introduce fine-grained, declarative RBAC for workspace content access during initialization
-   and termination, defined on `WorkspaceType`. Controllers access content with their own
+   and termination, defined on `WorkspaceType`. Granularity matches standard Kubernetes RBAC
+   (apiGroups / resources / verbs / resourceNames). Controllers access content with their own
    identity, scoped to explicitly declared permissions.
-3. Add a workspace content proxy to the terminating virtual workspace, matching the capability
+3. Clear audit attribution: initializer/terminator requests carry the controller's own
+   identity, not the workspace owner's, so audit logs unambiguously identify which controller
+   acted.
+4. Add a workspace content proxy to the terminating virtual workspace, matching the capability
    that already exists for the initializing virtual workspace.
-4. Add a `Terminating` phase for workspace visibility.
-5. Preserve backwards compatibility: WorkspaceTypes without explicit permissions fall back to
+5. Add a `Terminating` phase for workspace visibility.
+6. Preserve backwards compatibility: WorkspaceTypes without explicit permissions fall back to
    owner impersonation (current behavior).
 
 ### Non-Goals
@@ -61,10 +70,8 @@ The current workspace lifecycle has several gaps (see also
 - Changing direct workspace access patterns. The workspace content authorizer continues to
   handle direct access; the VW proxies handle lifecycle content access.
 - Per-controller custom impersonation identity selection.
-- Preventing users from deleting the auto-created initializer/terminator ClusterRoles and
-  ClusterRoleBindings inside the workspace. A user with sufficient RBAC could delete these
-  objects, which would break initializer/terminator content access. Protecting these objects
-  (e.g., via admission webhook or finalizers) is out of scope for now.
+- Per-workspace (instance-level) overrides of initializer/terminator permissions. Permissions
+  are declared once on the WorkspaceType and apply uniformly to all workspaces of that type.
 
 ## Proposal
 
@@ -121,11 +128,10 @@ type ExtraValue []string
 
 | Component | File | Change |
 |---|---|---|
-| Workspace admission | `pkg/admission/workspace/admission.go` | On workspace creation, set `ownerUser` on the Workspace (to be propagated to LogicalCluster) in addition to the existing annotation |
+| Workspace admission | `pkg/admission/workspace/admission.go` | On workspace creation, set `ownerUser` on the Workspace (to be propagated to LogicalCluster); stop setting the `experimental.tenancy.kcp.io/owner` annotation |
 | LogicalCluster admission | `pkg/admission/logicalcluster/admission.go` | Validate that `spec.ownerUser` is immutable after creation |
-| LogicalCluster controller | `pkg/reconciler/tenancy/logicalcluster/logicalcluster_controller.go` | Read owner from `spec.ownerUser` instead of annotation when creating `workspace-admin` CRB |
+| LogicalCluster controller | `pkg/reconciler/tenancy/logicalcluster/logicalcluster_controller.go` | Read owner from `spec.ownerUser` when creating `workspace-admin` CRB |
 | Metadata reconciler | `pkg/reconciler/core/logicalcluster/logicalcluster_reconcile_metadata.go` | Remove group-wiping logic and annotation handling entirely |
-| Workspace admission | `pkg/admission/workspace/admission.go` | Stop setting the `experimental.tenancy.kcp.io/owner` annotation |
 | Initializing VW content proxy | `pkg/virtual/initializingworkspaces/builder/build.go` | Read from `spec.ownerUser` only; remove annotation fallback |
 
 The `experimental.tenancy.kcp.io/owner` annotation is removed entirely in this change.
@@ -217,22 +223,43 @@ explicit permissions:
 
 When `initializerPermissions` or `terminatorPermissions` is set on the WorkspaceType:
 
-1. kcp automatically creates a ClusterRole and ClusterRoleBinding inside the workspace
-   (see "Automatic RBAC Creation" below).
-2. The VW proxy injects a synthetic group into the request context instead of impersonating
-   the owner.
-3. The request reaches the workspace with the **controller's own identity** plus the
-   synthetic group.
-4. RBAC inside the workspace evaluates the synthetic group against the auto-created
-   ClusterRole.
+1. The VW proxy evaluates the incoming request **in-process** against the WorkspaceType's
+   `initializerPermissions` / `terminatorPermissions` rules (verb / apiGroup / resource /
+   resourceName match) using the standard RBAC evaluation logic. This happens after the
+   existing `initialize`/`terminate` verb check and phase/presence validation.
+2. If the request is denied, the VW proxy returns 403 without ever forwarding to the shard.
+3. If allowed, the VW proxy forwards to the shard with the **controller's own identity**
+   plus a synthetic group (see "Synthetic Groups" below).
+4. On the shard side, the workspace content authorizer recognizes the synthetic group as a
+   "pre-authorized by VW" signal and allows the request. It does **not** re-evaluate the
+   WorkspaceType rules — the VW has already done that. This is a trivial trust check, not a
+   full authorizer.
 5. Audit logs show the controller's actual identity — clear attribution.
+
+This keeps the expensive work (rule evaluation) on the lifecycle path only: the VW proxy
+is the single place that knows about `initializerPermissions` / `terminatorPermissions`.
+The normal workspace authorization chain is **not** modified to evaluate these rules — it
+only needs to recognize and trust the synthetic group when set, and reject it when not.
+
+This is deliberately "magic/ephemeral" rather than "visible" RBAC: the rules live on the
+WorkspaceType (the source of truth) and are evaluated by the VW proxy on each request.
+This avoids:
+
+- Running lifecycle permission logic for every workspace request — only VW-bound requests
+  pay the cost.
+- Lifecycle permissions accidentally applying outside init/term phases — the VW proxy is
+  the only entry point that knows about these rules; direct shard requests cannot benefit.
+- Race conditions at workspace creation ("is the CRB there yet when the controller hits the
+  API?") — nothing needs to be created in the workspace before the controller can act.
+- Users accidentally or deliberately deleting the CRB and breaking lifecycle access.
+- Drift between WorkspaceType rules and materialized objects.
+- Finalizers/cleanup machinery for CRBs that get left behind after initialization.
 
 **Mode 2: Owner impersonation (fallback, backwards compatible)**
 
 When `initializerPermissions` or `terminatorPermissions` is empty/nil:
 
-1. The VW proxy impersonates the workspace owner from `spec.ownerUser` (or annotation
-   fallback).
+1. The VW proxy impersonates the workspace owner from `spec.ownerUser`.
 2. The request reaches the workspace as the owner, who has cluster-admin via the
    `workspace-admin` ClusterRoleBinding.
 3. This is the current behavior — no changes needed for existing controllers.
@@ -250,70 +277,55 @@ workspace path and the type name (e.g., `root:org:tenant`). This is already glob
 two WorkspaceTypes with the same name in different workspaces produce different identifiers.
 No clash is possible.
 
-These groups are only added by the VW proxy — they cannot be self-asserted by clients.
+These groups are only added by the VW proxy — they cannot be self-asserted by clients. As
+a defense-in-depth measure, the workspace content authorizer strips any `system:kcp:initializer:*`
+/ `system:kcp:terminator:*` groups from incoming requests that did not come through the VW
+proxy (i.e., direct requests to the shard).
 
-#### Automatic RBAC Creation
+#### Ephemeral (in-memory) RBAC Evaluation
 
-When a WorkspaceType has explicit permissions, kcp creates RBAC inside the workspace
-automatically. This happens in the LogicalCluster controller (same place that creates
-`workspace-admin` CRB).
+When a WorkspaceType has explicit `initializerPermissions` / `terminatorPermissions`, kcp
+does **not** create any ClusterRole or ClusterRoleBinding objects inside the workspace.
+Instead, the VW proxy evaluates the request in-process against the WorkspaceType spec
+before forwarding to the shard.
 
-For initializers (on workspace creation, before VW discovery):
-
-```yaml
-# Auto-created by kcp inside the workspace
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: system:kcp:initializer:<initializer-name>
-rules:
-  # Copied from WorkspaceType.spec.initializerPermissions
-  - apiGroups: [""]
-    resources: ["configmaps", "secrets", "namespaces"]
-    verbs: ["get", "list", "create", "update", "delete"]
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: system:kcp:initializer:<initializer-name>
-roleRef:
-  kind: ClusterRole
-  name: system:kcp:initializer:<initializer-name>
-subjects:
-  - kind: Group
-    name: system:kcp:initializer:<initializer-name>
-```
-
-For terminators (on workspace deletion, before terminating VW discovery):
+Conceptually the evaluation is equivalent to what RBAC would do if the following objects
+existed — but they do **not** exist as API objects, they are evaluated in memory from the
+WorkspaceType spec at request time:
 
 ```yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: system:kcp:terminator:<terminator-name>
-rules:
-  # Copied from WorkspaceType.spec.terminatorPermissions
-  - apiGroups: [""]
-    resources: ["*"]
-    verbs: ["get", "list", "delete"]
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: system:kcp:terminator:<terminator-name>
-roleRef:
-  kind: ClusterRole
-  name: system:kcp:terminator:<terminator-name>
-subjects:
-  - kind: Group
-    name: system:kcp:terminator:<terminator-name>
+# Virtual, in-memory only — NOT a real object in the workspace
+ClusterRole: system:kcp:initializer:<initializer-name>
+  rules: <from WorkspaceType.spec.initializerPermissions>
+ClusterRoleBinding: system:kcp:initializer:<initializer-name>
+  roleRef: system:kcp:initializer:<initializer-name>
+  subjects:
+    - kind: Group
+      name: system:kcp:initializer:<initializer-name>
 ```
+
+The VW proxy's evaluator:
+
+1. Resolves the WorkspaceType for the current workspace (via `LogicalCluster.spec.type` /
+   cached WorkspaceType informer).
+2. Evaluates the request's verb / apiGroup / resource / resourceName against the matching
+   `initializerPermissions` or `terminatorPermissions` rules using standard RBAC matching
+   semantics.
+3. Allows → forward to shard with controller identity + synthetic group.
+   Denies → return 403 immediately.
+
+Because rules live on the WorkspaceType and are evaluated on the fly, permission changes on
+the WorkspaceType take effect immediately for all workspaces of that type. There is no
+snapshot, no drift, no materialized state to reconcile. See the "Permission updates" note
+in Open Questions for the policy trade-off.
 
 #### Extending Workspace Types
 
 When `gamma` extends `alpha` and `beta`, each initializer/terminator is independent. A
-workspace of type `gamma` gets three separate sets of RBAC — one for each initializer's
-synthetic group with that initializer's permissions from its own WorkspaceType. No merging.
+workspace of type `gamma` is evaluated against three separate sets of rules — one per
+initializer's synthetic group, using that initializer's permissions from its own
+WorkspaceType. No merging. The authorizer looks up permissions from the WorkspaceType that
+**owns** the synthetic group, not from the workspace's own type.
 
 #### Content Proxy Authorization Flow
 
@@ -330,8 +342,16 @@ synthetic group with that initializer's permissions from its own WorkspaceType. 
    → OK: proceed
 
 4. VW checks WorkspaceType for explicit permissions
-   → initializerPermissions set: inject synthetic group, forward with controller identity
+   → initializerPermissions set:
+       a. Evaluate request in-process against initializerPermissions rules
+          - Denied: return 403 immediately, do not forward
+          - Allowed: forward to shard with controller identity + synthetic group
    → initializerPermissions empty: impersonate workspace owner (fallback)
+
+5. Shard receives forwarded request
+   → Workspace content authorizer sees synthetic group system:kcp:initializer:<name>:
+     allow (trust: VW has already authorized; only VW can inject this group)
+   → No WorkspaceType rule evaluation on the shard
 ```
 
 The same flow applies to the terminating virtual workspace, substituting `terminate` for
@@ -343,18 +363,29 @@ The workspace content authorizer (`pkg/authorization/workspace_content_authorize
 currently allows access only for `Initializing` and `Ready` phases. Changes needed:
 
 - Allow access for the `Terminating` phase (see Part 4).
-- Recognize synthetic groups (`system:kcp:initializer:*`, `system:kcp:terminator:*`) —
-  these bypass the phase gate since the VW proxy has already validated phase/presence.
+- Recognize synthetic groups (`system:kcp:initializer:*`, `system:kcp:terminator:*`) as a
+  "pre-authorized by VW" marker and allow the request. This is a trivial trust check — the
+  shard does not evaluate WorkspaceType rules, it delegates that entirely to the VW proxy.
+- Strip any `system:kcp:initializer:*` / `system:kcp:terminator:*` groups from requests that
+  did not arrive via the VW proxy (i.e. cannot be attributed to the front-proxy → VW path),
+  so clients cannot self-assert these groups by talking to a shard directly.
+
+No new authorizer is added to the workspace authorization chain. The heavy lifting of
+lifecycle permission evaluation is confined to the VW proxy, which means:
+
+- Normal (non-lifecycle) workspace requests are unaffected — no extra work per request.
+- Lifecycle permissions only apply to requests arriving via the VW proxy, which only
+  accepts them during `Initializing` / `Terminating` phases with a matching entry in
+  `status.initializers` / `status.terminators`. Access cannot leak outside those phases.
 
 #### Implementation Changes
 
 | Component | File | Change |
 |---|---|---|
 | WorkspaceType API | SDK `apis/tenancy/v1alpha1/types_workspacetype.go` | Add `InitializerPermissions` and `TerminatorPermissions` fields |
-| LogicalCluster controller | `pkg/reconciler/tenancy/logicalcluster/logicalcluster_controller.go` | Create initializer/terminator ClusterRole + CRB from WorkspaceType permissions |
-| Initializing VW content proxy | `pkg/virtual/initializingworkspaces/builder/build.go` | Two modes: synthetic group injection (explicit perms) or owner impersonation (fallback) |
-| Terminating VW content proxy | `pkg/virtual/terminatingworkspaces/builder/build.go` | Same two-mode logic |
-| Workspace content authorizer | `pkg/authorization/workspace_content_authorizer.go` | Allow `Terminating` phase; recognize synthetic groups |
+| Initializing VW content proxy | `pkg/virtual/initializingworkspaces/builder/build.go` | Two modes: in-process RBAC evaluation against `initializerPermissions` then forward with synthetic group (explicit perms), or owner impersonation (fallback) |
+| Terminating VW content proxy | `pkg/virtual/terminatingworkspaces/builder/build.go` | Same two-mode logic for `terminatorPermissions` |
+| Workspace content authorizer | `pkg/authorization/workspace_content_authorizer.go` | Allow `Terminating` phase; trust synthetic groups as pre-authorized; strip synthetic groups from non-VW requests |
 
 ### Part 3: Terminating Virtual Workspace Content Proxy
 
@@ -485,11 +516,13 @@ Phase 2: Terminating Phase and Content Proxy
   - Content proxy uses owner impersonation (same as initializing VW)
   - Add e2e tests for terminator content access
 
-Phase 3: Declarative RBAC on WorkspaceType
+Phase 3: Declarative RBAC on WorkspaceType (ephemeral)
   - Add initializerPermissions/terminatorPermissions to WorkspaceTypeSpec
-  - Implement automatic ClusterRole/CRB creation in LogicalCluster controller
-  - Implement synthetic group injection in VW content proxies
-  - Update workspace content authorizer to recognize synthetic groups
+  - Implement in-process RBAC evaluation in the initializing/terminating VW content
+    proxies (evaluate request against WorkspaceType permissions before forwarding)
+  - Implement synthetic group injection when forwarding
+  - Update workspace content authorizer to trust synthetic groups as pre-authorized
+    and strip them from non-VW requests
   - Fallback to owner impersonation when permissions are empty
   - Add e2e tests for fine-grained permissions
 ```
@@ -529,17 +562,11 @@ authors opt into fine-grained permissions.
    `terminatorPermissions` only reference API groups and resources that are available in the
    workspace? Or allow any rules and let RBAC evaluation handle mismatches?
 
-3. **RBAC cleanup.** For **terminating** workspaces, cleanup is not needed — once all
-   terminators are removed, the workspace is deleted along with everything inside it. For
-   **initializing** workspaces, when an initializer removes itself and the workspace
-   transitions to `Ready`, the auto-created ClusterRole/CRB is left behind but harmless —
-   the synthetic group is only injected by the VW proxy during initialization, so the rules
-   grant nothing to anyone in the `Ready` phase. Proactive cleanup is possible but not
-   required for correctness or security.
-
-4. **Permission updates.** The WorkspaceType already has a lifecycle precedent:
-   `defaultAPIBindingLifecycle` supports `InitializeOnly` (snapshot at creation) and
-   `Maintain` (continuously reconciled). For `initializerPermissions`/`terminatorPermissions`,
-   we use `InitializeOnly` semantics: permissions are copied into the workspace at creation
-   time and changes to the WorkspaceType do not affect existing workspaces. A `Maintain`
-   mode could be added later if needed, following the same pattern.
+2. **Permission updates — semantics of ephemeral evaluation.** Because rules are evaluated
+   live from the WorkspaceType, edits to the WorkspaceType take effect **immediately** for
+   all existing workspaces of that type. This differs from the `defaultAPIBindingLifecycle`
+   `InitializeOnly` vs `Maintain` split, which only matters for materialized state. With
+   ephemeral RBAC, there is no materialized state to snapshot — the WorkspaceType **is** the
+   state. This is intentional: one source of truth, no drift, no reconciler. Operators must
+   be aware that tightening permissions on a WorkspaceType is an immediate change for every
+   workspace of that type.

--- a/keps/core/0003-workspace-lifecycle-rbac.md
+++ b/keps/core/0003-workspace-lifecycle-rbac.md
@@ -3,9 +3,9 @@
 ## Summary
 
 Replace the annotation-based workspace owner identity with a structured API field on
-`LogicalCluster`, and introduce RBAC-gated impersonation for initializing and terminating
-virtual workspace content proxies. Additionally, add workspace content access to the
-terminating virtual workspace, which currently lacks it entirely.
+`LogicalCluster`, introduce fine-grained RBAC-based workspace content access for initializing
+and terminating virtual workspace content proxies, add a `Terminating` phase for visibility,
+and add workspace content access to the terminating virtual workspace.
 
 ## Motivation
 
@@ -13,61 +13,58 @@ The current workspace lifecycle has several gaps (see also
 [kcp-dev/kcp#3647](https://github.com/kcp-dev/kcp/issues/3647)):
 
 1. **Owner identity stored as annotation.** The workspace owner is serialized as JSON in the
-   `experimental.tenancy.kcp.io/owner` annotation on the Workspace object
-   (`staging/src/github.com/kcp-dev/sdk/apis/tenancy/v1alpha1/types_workspace.go:58-59`).
-   The initializing virtual workspace content proxy reads this annotation from the LogicalCluster
-   to impersonate the owner when forwarding requests
-   (`pkg/virtual/initializingworkspaces/builder/build.go:241-254`). Annotations are untyped,
-   unvalidated, and can be mutated by anyone with update access — making them unsuitable for
-   security-critical identity data.
+   `experimental.tenancy.kcp.io/owner` annotation on the Workspace object. Annotations are
+   untyped, unvalidated, and can be mutated by anyone with update access — making them
+   unsuitable for security-critical identity data.
 
 2. **Owner group information is wiped on Ready phase.** When a LogicalCluster transitions to
-   `Ready`, the metadata reconciler
-   (`pkg/reconciler/core/logicalcluster/logicalcluster_reconcile_metadata.go:99-117`) strips
-   all fields except `Username` from the owner annotation. This means by the time a workspace
-   reaches termination, the owner's groups, UID, and extra info are already lost. Even if the
-   terminating virtual workspace attempted the same impersonation mechanism as the initializing
-   VW, it would impersonate the owner without their groups — potentially breaking group-based
-   RBAC evaluation. This is also not backwards compatible: workspaces created before any fix
-   would already have lost the group data.
+   `Ready`, the metadata reconciler strips all fields except `Username` from the owner
+   annotation. By the time a workspace reaches termination, the owner's groups, UID, and extra
+   info are already lost.
 
-3. **Terminating workspaces have no content access.** The terminating virtual workspace
-   (`pkg/virtual/terminatingworkspaces/builder/build.go`) only exposes LogicalCluster
-   list/watch and status updates. Terminator controllers cannot access actual workspace
-   content to clean up resources. The workspace content authorizer
-   (`pkg/authorization/workspace_content_authorizer.go:112-114`) blocks all access for
-   workspaces not in `Initializing` or `Ready` phase.
+3. **Terminating workspaces have no content access.** The terminating virtual workspace only
+   exposes LogicalCluster list/watch and status updates. Terminator controllers cannot access
+   actual workspace content to clean up resources. The workspace content authorizer blocks all
+   access for workspaces not in `Initializing` or `Ready` phase.
 
-4. **No separate RBAC gate for workspace content access.** Currently, having the `initialize`
-   verb on a workspacetype implicitly grants access to the workspace content proxy (for the
-   initializing VW). There is no separate authorization step that distinguishes "can access
-   LogicalCluster VW endpoints" from "can access workspace content." The content proxy
-   impersonates the workspace owner — who has `cluster-admin` inside the workspace via the
-   `workspace-admin` ClusterRoleBinding
-   (`pkg/reconciler/tenancy/logicalcluster/logicalcluster_controller.go:236-250`) — but the
-   controller itself may be a service account with limited permissions. Not every controller
-   with VW access should automatically get this elevated content access.
+4. **No fine-grained permissions for workspace content access.** The initializing VW content
+   proxy impersonates the workspace owner — who has `cluster-admin` inside the workspace.
+   Having `initialize` on a workspacetype implicitly grants full cluster-admin content access.
+   There is no way to scope an initializer's permissions (e.g., read-only configmaps). Not
+   every controller needs full admin access to workspace content.
+
+5. **Misleading audit logs.** The content proxy impersonates the workspace owner identity.
+   Audit logs cannot distinguish whether a request came from the actual owner or a controller
+   impersonating them. With multiple initializers/terminators, controllers are
+   indistinguishable from each other and from the owner.
+
+6. **No `Terminating` phase.** Workspaces that are being terminated show as `Ready` in
+   `kubectl get workspaces`. There is no way to tell which workspaces are stuck in termination
+   without inspecting deletion timestamps and terminator lists.
 
 ### Goals
 
 1. Move workspace owner identity from annotation to a structured, immutable field on
    `LogicalCluster`.
-2. Introduce RBAC-gated impersonation on `WorkspaceType` so that controllers can be
-   explicitly authorized to access workspace content with elevated privileges during
-   initialization and termination. So not everybody with VW access automatically gets elevated access.
-3. Add a workspace content proxy to the terminating virtual workspace, matching the
-   capability that already exists for the initializing virtual workspace.
+2. Introduce fine-grained, declarative RBAC for workspace content access during initialization
+   and termination, defined on `WorkspaceType`. Controllers access content with their own
+   identity, scoped to explicitly declared permissions.
+3. Add a workspace content proxy to the terminating virtual workspace, matching the capability
+   that already exists for the initializing virtual workspace.
+4. Add a `Terminating` phase for workspace visibility.
+5. Preserve backwards compatibility: WorkspaceTypes without explicit permissions fall back to
+   owner impersonation (current behavior).
 
 ### Non-Goals
 
-- General-purpose workspace content access outside of init/term phases. The `impersonate`
-  verb on `workspacetypes` only applies to the virtual workspace content proxies, not to
-  direct workspace access.
-- Changing the workspace content authorizer phase gate. The authorizer continues to block
-  direct access to non-`Initializing`/non-`Ready` workspaces. The virtual workspace proxies
-  bypass this by hitting the shard directly with impersonation.
-- Per-initializer or per-terminator impersonation identity selection. All controllers with
-  the `impersonate` verb on a given WorkspaceType get the same elevated identity.
+- General-purpose workspace content access outside of init/term phases.
+- Changing direct workspace access patterns. The workspace content authorizer continues to
+  handle direct access; the VW proxies handle lifecycle content access.
+- Per-controller custom impersonation identity selection.
+- Preventing users from deleting the auto-created initializer/terminator ClusterRoles and
+  ClusterRoleBindings inside the workspace. A user with sufficient RBAC could delete these
+  objects, which would break initializer/terminator content access. Protecting these objects
+  (e.g., via admission webhook or finalizers) is out of scope for now.
 
 ## Proposal
 
@@ -75,8 +72,7 @@ The current workspace lifecycle has several gaps (see also
 
 #### API Changes
 
-Add a new type and field to `LogicalClusterSpec`
-(`staging/src/github.com/kcp-dev/sdk/apis/core/v1alpha1/logicalcluster_types.go`):
+Add a new type and field to `LogicalClusterSpec`:
 
 ```go
 type LogicalClusterSpec struct {
@@ -84,8 +80,9 @@ type LogicalClusterSpec struct {
 
     // ownerUser is the identity of the user who created this workspace.
     // Set by the system at workspace creation time. Immutable after creation.
-    // Used by virtual workspace content proxies to determine the default
-    // impersonation identity during initialization and termination.
+    // Used as impersonation identity when WorkspaceType does not define
+    // explicit initializerPermissions/terminatorPermissions, and for
+    // creating the workspace-admin ClusterRoleBinding.
     //
     // +optional
     OwnerUser *LogicalClusterOwnerUser `json:"ownerUser,omitempty"`
@@ -124,85 +121,201 @@ type ExtraValue []string
 
 | Component | File | Change |
 |---|---|---|
-| Workspace admission | `pkg/admission/workspace/admission.go:95-108` | On workspace creation, set `ownerUser` on the Workspace (to be propagated to LogicalCluster) in addition to the existing annotation |
+| Workspace admission | `pkg/admission/workspace/admission.go` | On workspace creation, set `ownerUser` on the Workspace (to be propagated to LogicalCluster) in addition to the existing annotation |
 | LogicalCluster admission | `pkg/admission/logicalcluster/admission.go` | Validate that `spec.ownerUser` is immutable after creation |
-| LogicalCluster controller | `pkg/reconciler/tenancy/logicalcluster/logicalcluster_controller.go:236-250` | Read owner from `spec.ownerUser` instead of annotation when creating `workspace-admin` CRB |
-| Initializing VW content proxy | `pkg/virtual/initializingworkspaces/builder/build.go:241-254` | Read from `spec.ownerUser` instead of annotation; fall back to annotation for migration |
+| LogicalCluster controller | `pkg/reconciler/tenancy/logicalcluster/logicalcluster_controller.go` | Read owner from `spec.ownerUser` instead of annotation when creating `workspace-admin` CRB |
+| Metadata reconciler | `pkg/reconciler/core/logicalcluster/logicalcluster_reconcile_metadata.go` | Remove group-wiping logic and annotation handling entirely |
+| Workspace admission | `pkg/admission/workspace/admission.go` | Stop setting the `experimental.tenancy.kcp.io/owner` annotation |
+| Initializing VW content proxy | `pkg/virtual/initializingworkspaces/builder/build.go` | Read from `spec.ownerUser` only; remove annotation fallback |
 
-#### Migration
+The `experimental.tenancy.kcp.io/owner` annotation is removed entirely in this change.
+There is no fallback — `spec.ownerUser` is the sole source of truth. Existing workspaces
+without `spec.ownerUser` set will not have owner identity available for impersonation;
+they must be recreated.
 
-During transition, the content proxy reads `spec.ownerUser` first, falling back to the
-`experimental.tenancy.kcp.io/owner` annotation. The annotation is deprecated and will be
-removed in a future release.
-
-### Part 2: RBAC-Gated Impersonation via WorkspaceType
+### Part 2: Declarative RBAC for Workspace Content Access
 
 #### Problem
 
-An initializer or terminator controller is typically a service account with narrow permissions:
-it can list/watch LogicalClusters via the virtual workspace and update their status. Currently,
-having the `initialize` or `terminate` verb on a workspacetype grants access to the VW's
-LogicalCluster endpoints, but also — implicitly and unconditionally — grants access to the
-workspace content proxy (for initializing VW). There is no separate RBAC gate that controls
-whether a controller is authorized to access workspace content.
+The current content proxy impersonates the workspace owner, giving controllers full
+cluster-admin access. This has several problems:
 
-Not every controller with VW access should automatically get workspace content access. The
-`impersonate` verb provides an explicit, separate authorization gate for content access.
+- **No fine-grained permissions.** An initializer that only needs to create ConfigMaps gets
+  full admin access to all resources in the workspace.
+- **Misleading audit logs.** All controllers appear as the workspace owner. Multiple
+  initializers/terminators are indistinguishable from each other and from the real owner.
+- **Implicit access.** Any controller with `initialize` automatically gets content access.
 
-#### New RBAC Verb: `impersonate`
+#### Solution: Permissions on WorkspaceType
 
-Introduce a new verb `impersonate` on the `workspacetypes` resource in the `tenancy.kcp.io`
-API group. This verb controls whether a controller is allowed to access workspace content
-through the virtual workspace content proxy. When granted, the proxy impersonates the workspace
-owner (who has `cluster-admin` inside the workspace via the `workspace-admin` ClusterRoleBinding
-created at `pkg/reconciler/tenancy/logicalcluster/logicalcluster_controller.go:236-250`).
+Add optional permission fields to `WorkspaceTypeSpec` that declare what initializer and
+terminator controllers can do inside workspaces of this type:
 
-The controller itself may be a service account with limited permissions. The `impersonate` verb
-is what explicitly authorizes it to operate as the owner — and therefore as `cluster-admin` —
-inside the workspace content.
+```go
+type WorkspaceTypeSpec struct {
+    // ...existing fields...
+
+    // initializerPermissions defines the RBAC rules to grant to initializer
+    // controllers inside workspaces of this type during initialization.
+    // If empty, the content proxy falls back to owner impersonation
+    // (full cluster-admin, backwards compatible).
+    //
+    // +optional
+    InitializerPermissions []rbacv1.PolicyRule `json:"initializerPermissions,omitempty"`
+
+    // terminatorPermissions defines the RBAC rules to grant to terminator
+    // controllers inside workspaces of this type during termination.
+    // If empty, the content proxy falls back to owner impersonation
+    // (full cluster-admin, backwards compatible).
+    //
+    // +optional
+    TerminatorPermissions []rbacv1.PolicyRule `json:"terminatorPermissions,omitempty"`
+}
+```
+
+Example WorkspaceType with fine-grained permissions:
+
+```yaml
+apiVersion: tenancy.kcp.io/v1alpha1
+kind: WorkspaceType
+metadata:
+  name: tenant
+spec:
+  initializer: true
+  terminator: true
+  initializerPermissions:
+    - apiGroups: [""]
+      resources: ["configmaps", "secrets", "namespaces"]
+      verbs: ["get", "list", "create", "update", "delete"]
+    - apiGroups: ["rbac.authorization.k8s.io"]
+      resources: ["clusterroles", "clusterrolebindings"]
+      verbs: ["get", "list", "create"]
+  terminatorPermissions:
+    - apiGroups: [""]
+      resources: ["*"]
+      verbs: ["get", "list", "delete"]
+```
+
+Example WorkspaceType without explicit permissions (backwards compatible):
+
+```yaml
+apiVersion: tenancy.kcp.io/v1alpha1
+kind: WorkspaceType
+metadata:
+  name: legacy
+spec:
+  initializer: true
+  # No initializerPermissions → falls back to owner impersonation
+```
+
+#### Two Modes of Content Access
+
+The VW content proxy operates in two modes based on whether the WorkspaceType defines
+explicit permissions:
+
+**Mode 1: Explicit permissions (new, preferred)**
+
+When `initializerPermissions` or `terminatorPermissions` is set on the WorkspaceType:
+
+1. kcp automatically creates a ClusterRole and ClusterRoleBinding inside the workspace
+   (see "Automatic RBAC Creation" below).
+2. The VW proxy injects a synthetic group into the request context instead of impersonating
+   the owner.
+3. The request reaches the workspace with the **controller's own identity** plus the
+   synthetic group.
+4. RBAC inside the workspace evaluates the synthetic group against the auto-created
+   ClusterRole.
+5. Audit logs show the controller's actual identity — clear attribution.
+
+**Mode 2: Owner impersonation (fallback, backwards compatible)**
+
+When `initializerPermissions` or `terminatorPermissions` is empty/nil:
+
+1. The VW proxy impersonates the workspace owner from `spec.ownerUser` (or annotation
+   fallback).
+2. The request reaches the workspace as the owner, who has cluster-admin via the
+   `workspace-admin` ClusterRoleBinding.
+3. This is the current behavior — no changes needed for existing controllers.
+
+#### Synthetic Groups
+
+For each initializer/terminator, the VW proxy injects a well-known group:
+
+- Initializers: `system:kcp:initializer:<initializer-name>`
+- Terminators: `system:kcp:terminator:<terminator-name>`
+
+The `<initializer-name>` / `<terminator-name>` is the fully qualified identifier produced by
+`initialization.InitializerForType` / `termination.TerminatorForType`, which encodes both the
+workspace path and the type name (e.g., `root:org:tenant`). This is already globally unique —
+two WorkspaceTypes with the same name in different workspaces produce different identifiers.
+No clash is possible.
+
+These groups are only added by the VW proxy — they cannot be self-asserted by clients.
+
+#### Automatic RBAC Creation
+
+When a WorkspaceType has explicit permissions, kcp creates RBAC inside the workspace
+automatically. This happens in the LogicalCluster controller (same place that creates
+`workspace-admin` CRB).
+
+For initializers (on workspace creation, before VW discovery):
+
+```yaml
+# Auto-created by kcp inside the workspace
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: system:kcp:initializer:<initializer-name>
+rules:
+  # Copied from WorkspaceType.spec.initializerPermissions
+  - apiGroups: [""]
+    resources: ["configmaps", "secrets", "namespaces"]
+    verbs: ["get", "list", "create", "update", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: system:kcp:initializer:<initializer-name>
+roleRef:
+  kind: ClusterRole
+  name: system:kcp:initializer:<initializer-name>
+subjects:
+  - kind: Group
+    name: system:kcp:initializer:<initializer-name>
+```
+
+For terminators (on workspace deletion, before terminating VW discovery):
 
 ```yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: universal-initializer
+  name: system:kcp:terminator:<terminator-name>
 rules:
-  # Gate 1: Can access the initializing virtual workspace (LogicalCluster list/watch/status)
-  - verbs: ["initialize"]
-    resources: ["workspacetypes"]
-    resourceNames: ["universal"]
-    apiGroups: ["tenancy.kcp.io"]
-  # Gate 2: Can access workspace content via proxy (impersonating the owner)
-  - verbs: ["impersonate"]
-    resources: ["workspacetypes"]
-    resourceNames: ["universal"]
-    apiGroups: ["tenancy.kcp.io"]
-```
-
-Similarly for terminators:
-
-```yaml
+  # Copied from WorkspaceType.spec.terminatorPermissions
+  - apiGroups: [""]
+    resources: ["*"]
+    verbs: ["get", "list", "delete"]
+---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+kind: ClusterRoleBinding
 metadata:
-  name: universal-terminator
-rules:
-  - verbs: ["terminate"]
-    resources: ["workspacetypes"]
-    resourceNames: ["universal"]
-    apiGroups: ["tenancy.kcp.io"]
-  - verbs: ["impersonate"]
-    resources: ["workspacetypes"]
-    resourceNames: ["universal"]
-    apiGroups: ["tenancy.kcp.io"]
+  name: system:kcp:terminator:<terminator-name>
+roleRef:
+  kind: ClusterRole
+  name: system:kcp:terminator:<terminator-name>
+subjects:
+  - kind: Group
+    name: system:kcp:terminator:<terminator-name>
 ```
 
-A controller with only `initialize`/`terminate` (without `impersonate`) can list/watch
-LogicalClusters and update their status, but **cannot** access workspace content.
+#### Extending Workspace Types
+
+When `gamma` extends `alpha` and `beta`, each initializer/terminator is independent. A
+workspace of type `gamma` gets three separate sets of RBAC — one for each initializer's
+synthetic group with that initializer's permissions from its own WorkspaceType. No merging.
 
 #### Content Proxy Authorization Flow
-
-When a controller accesses workspace content through the virtual workspace proxy:
 
 ```
 1. Controller sends request to VW content endpoint
@@ -216,56 +329,50 @@ When a controller accesses workspace content through the virtual workspace proxy
    → Phase != Initializing or initializer not in status.initializers: 403 Forbidden
    → OK: proceed
 
-4. VW checks "impersonate" verb on workspacetypes (NEW)
-   → Allow: proxy impersonates workspace owner from spec.ownerUser
-   → Deny/NoOpinion: 403 Forbidden — content access not authorized
+4. VW checks WorkspaceType for explicit permissions
+   → initializerPermissions set: inject synthetic group, forward with controller identity
+   → initializerPermissions empty: impersonate workspace owner (fallback)
 ```
 
 The same flow applies to the terminating virtual workspace, substituting `terminate` for
 `initialize` and checking `deletionTimestamp` + `status.terminators`.
 
-#### Impersonation Target
+#### Workspace Content Authorizer Changes
 
-The proxy always impersonates the **workspace owner** from `spec.ownerUser` on the
-LogicalCluster. The owner is bound to `cluster-admin` inside the workspace via the
-`workspace-admin` ClusterRoleBinding
-(`pkg/reconciler/tenancy/logicalcluster/logicalcluster_controller.go:236-250`), giving the
-proxied request full access to workspace content.
+The workspace content authorizer (`pkg/authorization/workspace_content_authorizer.go`)
+currently allows access only for `Initializing` and `Ready` phases. Changes needed:
 
-The `impersonate` verb does not change who is impersonated — it gates whether the controller
-is allowed to access content at all. This provides a clear separation:
-
-- `initialize`/`terminate` → access to LogicalCluster VW endpoints
-- `impersonate` → access to workspace content (as the owner)
+- Allow access for the `Terminating` phase (see Part 4).
+- Recognize synthetic groups (`system:kcp:initializer:*`, `system:kcp:terminator:*`) —
+  these bypass the phase gate since the VW proxy has already validated phase/presence.
 
 #### Implementation Changes
 
 | Component | File | Change |
 |---|---|---|
-| Initializing VW content proxy | `pkg/virtual/initializingworkspaces/builder/build.go:223-288` | Add delegated SAR check for `impersonate` verb before proxying; deny if not authorized |
-| Terminating VW content proxy | New code (see Part 3) | Same `impersonate` check before proxying |
-| ClusterRole replication | `pkg/reconciler/tenancy/replicateclusterrole/replicateclusterrole_controller.go:60` | Add `impersonate` to the set of verbs that trigger replication |
+| WorkspaceType API | SDK `apis/tenancy/v1alpha1/types_workspacetype.go` | Add `InitializerPermissions` and `TerminatorPermissions` fields |
+| LogicalCluster controller | `pkg/reconciler/tenancy/logicalcluster/logicalcluster_controller.go` | Create initializer/terminator ClusterRole + CRB from WorkspaceType permissions |
+| Initializing VW content proxy | `pkg/virtual/initializingworkspaces/builder/build.go` | Two modes: synthetic group injection (explicit perms) or owner impersonation (fallback) |
+| Terminating VW content proxy | `pkg/virtual/terminatingworkspaces/builder/build.go` | Same two-mode logic |
+| Workspace content authorizer | `pkg/authorization/workspace_content_authorizer.go` | Allow `Terminating` phase; recognize synthetic groups |
 
 ### Part 3: Terminating Virtual Workspace Content Proxy
 
 #### Current State
 
-The terminating virtual workspace (`pkg/virtual/terminatingworkspaces/builder/build.go:56-159`)
-exposes two sub-workspaces:
+The terminating virtual workspace exposes two sub-workspaces:
 
 | Name | Purpose |
 |---|---|
 | `wildcardLogicalClusters` | List/watch LogicalClusters with deletionTimestamp, filtered by terminator label |
 | `logicalClusters` | Get/update individual LogicalCluster status (remove own terminator only) |
 
-There is no `workspaceContent` sub-workspace. Terminators cannot access resources inside the
-workspace to clean up before deletion.
+There is no `workspaceContent` sub-workspace.
 
 #### Proposed Addition
 
 Add a third sub-workspace `workspaceContent` to the terminating virtual workspace, mirroring
-the pattern in the initializing virtual workspace
-(`pkg/virtual/initializingworkspaces/builder/build.go:165-291`).
+the pattern in the initializing virtual workspace.
 
 URL pattern:
 ```
@@ -276,43 +383,42 @@ URL pattern:
 
 ```
 1. Parse terminator name from URL path (existing digestUrl function)
-
 2. Reject if cluster is wildcard (content access requires specific cluster)
-
 3. Reject if path is a logicalclusters.core.kcp.io request
    (handled by the existing logicalClusters sub-workspace)
-
 4. Look up LogicalCluster from informer cache
-
 5. Validate:
    - LogicalCluster has deletionTimestamp set
    - Terminator is present in status.terminators
    → Reject with 403 if either check fails
-
-6. Check "impersonate" verb on workspacetypes for this terminator (Part 2)
-   → Deny/NoOpinion: 403 Forbidden — content access not authorized
-   → Allow: proceed
-
-7. Read owner identity from spec.ownerUser on LogicalCluster
-
-8. Reverse-proxy request to the workspace shard, impersonating the owner
+6. Check WorkspaceType for explicit terminatorPermissions
+   → Set: inject synthetic group, forward with controller identity
+   → Empty: impersonate workspace owner (fallback)
+7. Reverse-proxy request to the workspace shard
 ```
 
-#### Implementation Changes
-
-| Component | File | Change |
-|---|---|---|
-| Terminating VW builder | `pkg/virtual/terminatingworkspaces/builder/build.go` | Add `workspaceContent` handler as third named VW; accept `wildcardKcpInformers` parameter |
-| Terminating VW builder | `pkg/virtual/terminatingworkspaces/builder/build.go:61-66` | Add `workspaceContentName` constant |
-| Terminating VW registration | Where `BuildVirtualWorkspace` is called | Pass `wildcardKcpInformers` (same as initializing VW does) |
-
-The `workspaceContent` handler for the terminating VW is structurally identical to
-`pkg/virtual/initializingworkspaces/builder/build.go:165-291`, with these differences:
+The handler is structurally identical to the initializing VW content proxy, with:
 
 - Checks `status.terminators` instead of `status.initializers`
 - Checks `deletionTimestamp` is set instead of `phase == Initializing`
-- Uses the `termination.TypeFrom` function instead of `initialization.TypeFrom`
-- Requires `impersonate` verb to access content (same as initializing VW after this proposal)
+- Uses `termination.TypeFrom` instead of `initialization.TypeFrom`
+- Reads `terminatorPermissions` instead of `initializerPermissions`
+
+### Part 4: Terminating Phase
+
+#### Current State
+
+Workspaces have these phases: `Scheduling`, `Initializing`, `Ready`. A workspace that is
+being terminated still shows `Ready` — there is no way to distinguish active workspaces
+from stuck-terminating ones in `kubectl get workspaces`.
+
+#### Change
+
+Add `LogicalClusterPhaseTerminating` to the phase enum. The metadata reconciler sets this
+phase when a workspace has a `deletionTimestamp`.
+
+The workspace content authorizer is updated to allow content access for the `Terminating`
+phase (in addition to `Initializing` and `Ready`).
 
 ## RBAC Summary
 
@@ -323,9 +429,11 @@ The following table summarizes the verbs on `workspacetypes` and what they gate:
 | `use` | `workspacetypes` | Can create workspaces of this type | Workspace admission |
 | `initialize` | `workspacetypes` | Can access the initializing virtual workspace | Initializing VW authorizer |
 | `terminate` | `workspacetypes` | Can access the terminating virtual workspace | Terminating VW authorizer |
-| `impersonate` | `workspacetypes` | Can access workspace content via proxy (impersonating the owner) during init/term | VW content proxy (NEW) |
 
-Example: a controller that initializes workspaces of type `tenant` and needs content access:
+Content access scope is controlled declaratively on the WorkspaceType, not via additional
+RBAC verbs.
+
+Example: a controller that initializes workspaces of type `tenant`:
 
 ```yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -333,7 +441,7 @@ kind: ClusterRole
 metadata:
   name: tenant-initializer
 rules:
-  - verbs: ["initialize", "impersonate"]
+  - verbs: ["initialize"]
     resources: ["workspacetypes"]
     resourceNames: ["tenant"]
     apiGroups: ["tenancy.kcp.io"]
@@ -352,160 +460,86 @@ subjects:
     namespace: default
 ```
 
-This ClusterRole and ClusterRoleBinding must exist in the workspace where the `tenant`
-WorkspaceType is defined. The `replicateclusterrole` controller
-(`pkg/reconciler/tenancy/replicateclusterrole/replicateclusterrole_controller.go:60`)
-ensures ClusterRoles with `use`, `initialize`, `terminate`, or `impersonate` verbs on
-`workspacetypes` are replicated across the hierarchy.
+The `initialize` verb grants VW access. Content access scope is determined by the
+WorkspaceType's `initializerPermissions`. If empty, falls back to owner impersonation
+(cluster-admin).
 
 ## Implementation Phases
 
 ```
-Phase 1: Owner Identity (Part 1)
+Phase 1: Owner Identity and Annotation Removal
   - Add LogicalClusterOwnerUser type and ownerUser field to LogicalClusterSpec
-  - Update workspace admission to populate ownerUser
+  - Update workspace admission to populate ownerUser and stop setting annotation
   - Update logicalcluster admission to enforce immutability
   - Update logicalcluster controller to read ownerUser for workspace-admin CRB
-  - Update initializing VW content proxy to read from spec.ownerUser
-  - Deprecate experimental.tenancy.kcp.io/owner annotation
+  - Update initializing VW content proxy to read from spec.ownerUser only
+  - Remove experimental.tenancy.kcp.io/owner annotation entirely
+  - Remove group-wiping logic from metadata reconcilers
 
-Phase 2: Impersonation RBAC (Part 2)
-  - Add "impersonate" verb check to initializing VW authorizer and content proxy
-  - Add "impersonate" to replicateclusterrole verb set
-  - Add e2e tests for impersonation gating
-
-Phase 3: Terminating VW Content Access (Part 3)
+Phase 2: Terminating Phase and Content Proxy
+  - Add LogicalClusterPhaseTerminating
+  - Update metadata reconciler to set Terminating phase on deletion
+  - Update workspace content authorizer to allow Terminating phase
   - Add workspaceContent handler to terminating VW
   - Wire informers into terminating VW builder
-  - Integrate impersonation RBAC from Phase 2
+  - Content proxy uses owner impersonation (same as initializing VW)
   - Add e2e tests for terminator content access
+
+Phase 3: Declarative RBAC on WorkspaceType
+  - Add initializerPermissions/terminatorPermissions to WorkspaceTypeSpec
+  - Implement automatic ClusterRole/CRB creation in LogicalCluster controller
+  - Implement synthetic group injection in VW content proxies
+  - Update workspace content authorizer to recognize synthetic groups
+  - Fallback to owner impersonation when permissions are empty
+  - Add e2e tests for fine-grained permissions
 ```
-
-## Relationship to Existing Issues
-
-This proposal addresses [kcp-dev/kcp#3647](https://github.com/kcp-dev/kcp/issues/3647)
-("Allow accessing workspace content through terminating virtualworkspace").
-
-That issue identified two core problems:
-1. The owner annotation's group info is wiped when a workspace reaches Ready
-   (`logicalcluster_reconcile_metadata.go:99-117`), making owner impersonation impossible
-   for terminators.
-2. The terminating VW has no content proxy at all.
-
-The issue discussion considered several approaches:
-- **Not wiping group data**: Would fix the immediate problem but is not backwards compatible
-  for existing workspaces, and still couples content access to the owner identity.
-- **Dynamically creating RBAC**: For controllers with `terminate`/`initialize` verbs, create
-  ephemeral ClusterRoleBindings granting workspace content access. This adds complexity around
-  lifecycle management of those RBAC objects.
-- **God-like permissions for the VW**: Giving the terminating VW system-level access. Too
-  broad and insecure.
-
-This proposal takes a different approach: structured owner identity (solving the data-loss
-problem) combined with RBAC-gated impersonation (decoupling content access from the owner
-entirely). The `impersonate` verb on workspacetypes provides explicit, auditable authorization
-for elevated access without ephemeral RBAC objects or annotation hacks.
-
-### Backwards Compatibility
-
-For workspaces created before this enhancement:
-- **Owner identity**: The `spec.ownerUser` field will not be set. The content proxy falls back
-  to the annotation. If the annotation has already been stripped to username-only (workspace
-  reached Ready), the owner can still be impersonated by username — the `workspace-admin`
-  ClusterRoleBinding (`pkg/reconciler/tenancy/logicalcluster/logicalcluster_controller.go:236-250`)
-  binds by username, not by group, so `cluster-admin` access still works.
-- **Impersonate verb**: Controllers with the `impersonate` verb bypass the owner identity
-  entirely, using the `kcp-admin` system identity. This works regardless of whether
-  `spec.ownerUser` or the annotation exists.
-- **Group-wiping removal**: As part of Phase 1, the group-wiping logic in
-  `logicalcluster_reconcile_metadata.go:99-117` should be removed. With owner identity moving
-  to an immutable spec field, there is no longer a reason to strip data from the annotation.
 
 ## Breaking Changes
 
-This enhancement introduces a **breaking change** in the authorization model for virtual
-workspace content access.
+**Phase 1: Annotation removal.** The `experimental.tenancy.kcp.io/owner` annotation is
+removed entirely. Code that reads owner identity from the annotation must switch to
+`spec.ownerUser`. Existing workspaces without `spec.ownerUser` set will not have owner
+identity available — they must be recreated.
 
-### Before
+**Phase 2: Terminating phase.** Workspaces that are being deleted will transition from
+`Ready` to `Terminating`. Code that checks for `phase == Ready` to determine if a workspace
+is usable may need to account for this new phase. The workspace content authorizer is updated
+to allow both phases.
 
-Any controller with the `initialize` verb on a `workspacetypes` resource could access
-workspace content through the initializing virtual workspace content proxy. The `initialize`
-verb served as a single gate for both LogicalCluster VW endpoints (list/watch/status) and
-workspace content (creating namespaces, configmaps, etc. inside the workspace). There was no
-separate authorization step for content access — it was implicitly granted.
+Phase 3 is **not a breaking change** for existing controllers. WorkspaceTypes without
+explicit `initializerPermissions`/`terminatorPermissions` fall back to owner impersonation,
+preserving the current behavior. Controllers only need to be updated when WorkspaceType
+authors opt into fine-grained permissions.
 
-### After
+## Backwards Compatibility
 
-Content access through the virtual workspace content proxy now requires the **`impersonate`**
-verb on the `workspacetypes` resource **in addition to** `initialize` or `terminate`.
+- **Owner identity**: The `experimental.tenancy.kcp.io/owner` annotation is removed. Existing
+  workspaces without `spec.ownerUser` will not have owner identity available for the
+  impersonation fallback. This is a breaking change — such workspaces must be recreated.
+  The `workspace-admin` CRB is unaffected (it binds by username from the spec field).
+- **WorkspaceType permissions**: Empty permissions = owner impersonation = current behavior.
+  No changes needed for existing WorkspaceTypes or controllers.
+- **Terminating phase**: New phase value. Code that only checks `Ready` continues to work
+  for active workspaces. Code that needs to distinguish active from terminating can check
+  for the new phase.
 
-- `initialize` or `terminate` alone → access to LogicalCluster VW endpoints only
-- `initialize` + `impersonate` → access to LogicalCluster VW endpoints **and** workspace content
-- `terminate` + `impersonate` → access to LogicalCluster VW endpoints **and** workspace content
+## Open Questions & Follow-ups
 
-### Impact
+1. **Permission validation.** Should kcp validate that `initializerPermissions` /
+   `terminatorPermissions` only reference API groups and resources that are available in the
+   workspace? Or allow any rules and let RBAC evaluation handle mismatches?
 
-**Existing initializer controllers that access workspace content will break** unless their
-ClusterRoles are updated to include the `impersonate` verb. Controllers that only list/watch
-LogicalClusters and update their status (i.e., do not access workspace content) are unaffected.
+3. **RBAC cleanup.** For **terminating** workspaces, cleanup is not needed — once all
+   terminators are removed, the workspace is deleted along with everything inside it. For
+   **initializing** workspaces, when an initializer removes itself and the workspace
+   transitions to `Ready`, the auto-created ClusterRole/CRB is left behind but harmless —
+   the synthetic group is only injected by the VW proxy during initialization, so the rules
+   grant nothing to anyone in the `Ready` phase. Proactive cleanup is possible but not
+   required for correctness or security.
 
-**Required migration**: For any ClusterRole that grants `initialize` or `terminate` on
-`workspacetypes` and whose controller accesses workspace content through the VW proxy, add
-`impersonate` to the verbs:
-
-```yaml
-# Before
-rules:
-  - verbs: ["initialize"]
-    resources: ["workspacetypes"]
-    resourceNames: ["my-type"]
-    apiGroups: ["tenancy.kcp.io"]
-
-# After
-rules:
-  - verbs: ["initialize", "impersonate"]
-    resources: ["workspacetypes"]
-    resourceNames: ["my-type"]
-    apiGroups: ["tenancy.kcp.io"]
-```
-
-The same applies to `terminate`:
-
-```yaml
-# Before
-rules:
-  - verbs: ["terminate"]
-    resources: ["workspacetypes"]
-    resourceNames: ["my-type"]
-    apiGroups: ["tenancy.kcp.io"]
-
-# After
-rules:
-  - verbs: ["terminate", "impersonate"]
-    resources: ["workspacetypes"]
-    resourceNames: ["my-type"]
-    apiGroups: ["tenancy.kcp.io"]
-```
-
-## Open Questions
-
-1. **Should `impersonate` without `initialize`/`terminate` be meaningful?**
-   Currently, `impersonate` only applies to controllers that already have VW access via
-   `initialize` or `terminate`. The content proxy requires both: VW access (`initialize`/
-   `terminate`) AND content access (`impersonate`). Should `impersonate` alone ever grant
-   anything?
-
-2. **Annotation removal timeline.**
-   How long should the `experimental.tenancy.kcp.io/owner` annotation be supported as a
-   fallback before removal?
-
-3. **Should the group-wiping logic be removed entirely or made conditional?**
-   The current code strips group/UID/extra from the owner annotation on Ready. With
-   `spec.ownerUser` as the source of truth, the annotation becomes redundant. Should
-   we stop wiping immediately, or keep the behavior until the annotation is fully deprecated?
-
-4. **Should the existing initializing VW content proxy require `impersonate`?**
-   Today, any controller with the `initialize` verb can access workspace content implicitly.
-   Adding the `impersonate` requirement is a breaking change for existing initializer
-   controllers. Should this be enforced immediately or introduced with a deprecation period
-   where the old behavior (implicit content access with `initialize` only) is preserved?
+4. **Permission updates.** The WorkspaceType already has a lifecycle precedent:
+   `defaultAPIBindingLifecycle` supports `InitializeOnly` (snapshot at creation) and
+   `Maintain` (continuously reconciled). For `initializerPermissions`/`terminatorPermissions`,
+   we use `InitializeOnly` semantics: permissions are copied into the workspace at creation
+   time and changes to the WorkspaceType do not affect existing workspaces. A `Maintain`
+   mode could be added later if needed, following the same pattern.

--- a/keps/core/0003-workspace-lifecycle-rbac.md
+++ b/keps/core/0003-workspace-lifecycle-rbac.md
@@ -277,10 +277,15 @@ workspace path and the type name (e.g., `root:org:tenant`). This is already glob
 two WorkspaceTypes with the same name in different workspaces produce different identifiers.
 No clash is possible.
 
-These groups are only added by the VW proxy — they cannot be self-asserted by clients. As
-a defense-in-depth measure, the workspace content authorizer strips any `system:kcp:initializer:*`
-/ `system:kcp:terminator:*` groups from incoming requests that did not come through the VW
-proxy (i.e., direct requests to the shard).
+These groups are only added by the VW proxy — they cannot be self-asserted by clients.
+This is enforced by the front-proxy's existing group filtering mechanism: the
+`--authentication-drop-groups` default list is extended to include `system:kcp:initializer:*`
+and `system:kcp:terminator:*`. This strips these groups from **all** client-asserted requests
+entering the front-proxy, before any routing occurs. The VW proxy (which runs inside the
+front-proxy process) then adds the synthetic groups **after** auth filtering when constructing
+the forwarded request to the shard. This is the same pattern used for
+`system:kcp:logical-cluster-admin` today — dropped at the front-proxy gate, injected only
+by trusted internal code paths.
 
 #### Ephemeral (in-memory) RBAC Evaluation
 
@@ -366,9 +371,9 @@ currently allows access only for `Initializing` and `Ready` phases. Changes need
 - Recognize synthetic groups (`system:kcp:initializer:*`, `system:kcp:terminator:*`) as a
   "pre-authorized by VW" marker and allow the request. This is a trivial trust check — the
   shard does not evaluate WorkspaceType rules, it delegates that entirely to the VW proxy.
-- Strip any `system:kcp:initializer:*` / `system:kcp:terminator:*` groups from requests that
-  did not arrive via the VW proxy (i.e. cannot be attributed to the front-proxy → VW path),
-  so clients cannot self-assert these groups by talking to a shard directly.
+  Synthetic groups cannot be self-asserted by clients because the front-proxy's
+  `--authentication-drop-groups` strips them from all incoming requests before routing (see
+  "Synthetic Groups" above).
 
 No new authorizer is added to the workspace authorization chain. The heavy lifting of
 lifecycle permission evaluation is confined to the VW proxy, which means:
@@ -385,7 +390,8 @@ lifecycle permission evaluation is confined to the VW proxy, which means:
 | WorkspaceType API | SDK `apis/tenancy/v1alpha1/types_workspacetype.go` | Add `InitializerPermissions` and `TerminatorPermissions` fields |
 | Initializing VW content proxy | `pkg/virtual/initializingworkspaces/builder/build.go` | Two modes: in-process RBAC evaluation against `initializerPermissions` then forward with synthetic group (explicit perms), or owner impersonation (fallback) |
 | Terminating VW content proxy | `pkg/virtual/terminatingworkspaces/builder/build.go` | Same two-mode logic for `terminatorPermissions` |
-| Workspace content authorizer | `pkg/authorization/workspace_content_authorizer.go` | Allow `Terminating` phase; trust synthetic groups as pre-authorized; strip synthetic groups from non-VW requests |
+| Workspace content authorizer | `pkg/authorization/workspace_content_authorizer.go` | Allow `Terminating` phase; trust synthetic groups as pre-authorized |
+| Front-proxy group filtering | `pkg/proxy/options/authentication.go` | Add `system:kcp:initializer:*` and `system:kcp:terminator:*` to `--authentication-drop-groups` defaults |
 
 ### Part 3: Terminating Virtual Workspace Content Proxy
 
@@ -522,7 +528,8 @@ Phase 3: Declarative RBAC on WorkspaceType (ephemeral)
     proxies (evaluate request against WorkspaceType permissions before forwarding)
   - Implement synthetic group injection when forwarding
   - Update workspace content authorizer to trust synthetic groups as pre-authorized
-    and strip them from non-VW requests
+  - Add synthetic groups to front-proxy `--authentication-drop-groups` defaults
+    to prevent client self-assertion
   - Fallback to owner impersonation when permissions are empty
   - Add e2e tests for fine-grained permissions
 ```

--- a/keps/core/0003-workspace-lifecycle-rbac.md
+++ b/keps/core/0003-workspace-lifecycle-rbac.md
@@ -421,6 +421,72 @@ For workspaces created before this enhancement:
   `logicalcluster_reconcile_metadata.go:99-117` should be removed. With owner identity moving
   to an immutable spec field, there is no longer a reason to strip data from the annotation.
 
+## Breaking Changes
+
+This enhancement introduces a **breaking change** in the authorization model for virtual
+workspace content access.
+
+### Before
+
+Any controller with the `initialize` verb on a `workspacetypes` resource could access
+workspace content through the initializing virtual workspace content proxy. The `initialize`
+verb served as a single gate for both LogicalCluster VW endpoints (list/watch/status) and
+workspace content (creating namespaces, configmaps, etc. inside the workspace). There was no
+separate authorization step for content access — it was implicitly granted.
+
+### After
+
+Content access through the virtual workspace content proxy now requires the **`impersonate`**
+verb on the `workspacetypes` resource **in addition to** `initialize` or `terminate`.
+
+- `initialize` or `terminate` alone → access to LogicalCluster VW endpoints only
+- `initialize` + `impersonate` → access to LogicalCluster VW endpoints **and** workspace content
+- `terminate` + `impersonate` → access to LogicalCluster VW endpoints **and** workspace content
+
+### Impact
+
+**Existing initializer controllers that access workspace content will break** unless their
+ClusterRoles are updated to include the `impersonate` verb. Controllers that only list/watch
+LogicalClusters and update their status (i.e., do not access workspace content) are unaffected.
+
+**Required migration**: For any ClusterRole that grants `initialize` or `terminate` on
+`workspacetypes` and whose controller accesses workspace content through the VW proxy, add
+`impersonate` to the verbs:
+
+```yaml
+# Before
+rules:
+  - verbs: ["initialize"]
+    resources: ["workspacetypes"]
+    resourceNames: ["my-type"]
+    apiGroups: ["tenancy.kcp.io"]
+
+# After
+rules:
+  - verbs: ["initialize", "impersonate"]
+    resources: ["workspacetypes"]
+    resourceNames: ["my-type"]
+    apiGroups: ["tenancy.kcp.io"]
+```
+
+The same applies to `terminate`:
+
+```yaml
+# Before
+rules:
+  - verbs: ["terminate"]
+    resources: ["workspacetypes"]
+    resourceNames: ["my-type"]
+    apiGroups: ["tenancy.kcp.io"]
+
+# After
+rules:
+  - verbs: ["terminate", "impersonate"]
+    resources: ["workspacetypes"]
+    resourceNames: ["my-type"]
+    apiGroups: ["tenancy.kcp.io"]
+```
+
 ## Open Questions
 
 1. **Should `impersonate` without `initialize`/`terminate` be meaningful?**


### PR DESCRIPTION
## Summary

Enhancement proposal for workspace lifecycle content access during initialization and termination phases.

Addresses [kcp-dev/kcp#3647](https://github.com/kcp-dev/kcp/issues/3647).

## What this proposes

Three changes to the workspace lifecycle RBAC model:

1. **Structured owner identity on LogicalCluster** — Replace the `experimental.tenancy.kcp.io/owner` annotation (which gets its group info [wiped on Ready](https://github.com/kcp-dev/kcp/blob/main/pkg/reconciler/core/logicalcluster/logicalcluster_reconcile_metadata.go#L99-L117)) with an immutable `spec.ownerUser` field on `LogicalCluster`.

2. **New `impersonate` RBAC verb on `workspacetypes`** — Separate authorization gate for workspace content access via the VW proxy. Today, `initialize` implicitly grants content access. With this change:
   - `initialize`/`terminate` → access to LogicalCluster VW endpoints (list/watch/status)
   - `impersonate` → access to workspace content (proxy impersonates the owner, who is `cluster-admin`)
   
   Not every controller with VW access should automatically get elevated content access.

3. **Terminating VW content proxy** — Add a `workspaceContent` handler to the terminating virtual workspace, matching the capability that already exists for the initializing VW. Gated by the `impersonate` verb.

## Why

- The owner annotation is fragile (untyped JSON, mutable) and its group data is wiped when a workspace reaches Ready — making owner impersonation impossible for terminators
- Terminators currently cannot access workspace content to clean up resources, causing workspaces to get stuck in `Deleting`
- There is no explicit RBAC gate distinguishing "can watch LogicalClusters" from "can operate as cluster-admin inside workspace content"

## Key design decisions

- The proxy **always impersonates the owner** — the `impersonate` verb gates access, not identity
- Phased implementation: owner identity → impersonate verb → terminating VW content proxy
- Backwards compatible: falls back to annotation when `spec.ownerUser` is not set